### PR TITLE
Update commons-collections to 3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
             <type>jar</type>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Summary:
- update commons-collections from 3.2.1 to 3.2.2

Why:
commons-collections 3.2.1 is the old vulnerable line. Version 3.2.2 is the maintained 3.x release that disables unsafe deserialization by default.

Verification:
- relied on existing GitHub Actions validation for this repo